### PR TITLE
Add roaming logic for enemies

### DIFF
--- a/czarDOOM
+++ b/czarDOOM
@@ -63,6 +63,9 @@
   let roomIndex = 0, HP = 10000;
   const TOTAL_ROOMS      = 10;
   const ENEMIES_PER_ROOM = 5;
+  const ROOM_SIZE        = 40;
+  const ROOM_GAP         = 5;
+  const ROOM_STEP        = ROOM_SIZE + ROOM_GAP;
 
   // tekstura główki patyczaków
   const headTexture = new THREE.TextureLoader().load(
@@ -121,21 +124,21 @@
     scene.add(floor);
 
     // budowanie pokoi
-    const size = 40, height = 20;
+    const height = 20;
     for(let i=0; i<TOTAL_ROOMS; i++){
       const room = new THREE.Group();
       const tex  = new THREE.TextureLoader().load('https://i.imgur.com/wsUxz75.jpeg');
       const mat  = new THREE.MeshStandardMaterial({ map: tex });
       ['front','back','left','right'].forEach(side=>{
-        const geo = new THREE.PlaneGeometry(size, height);
+        const geo = new THREE.PlaneGeometry(ROOM_SIZE, height);
         const mesh = new THREE.Mesh(geo, mat);
-        if(side==='front') mesh.position.set(0, height/2, -size/2);
-        if(side==='back')  { mesh.position.set(0, height/2, size/2); mesh.rotation.y = Math.PI; }
-        if(side==='left')  { mesh.position.set(-size/2, height/2, 0); mesh.rotation.y = Math.PI/2; }
-        if(side==='right') { mesh.position.set(size/2, height/2, 0); mesh.rotation.y = -Math.PI/2; }
+        if(side==='front') mesh.position.set(0, height/2, -ROOM_SIZE/2);
+        if(side==='back')  { mesh.position.set(0, height/2, ROOM_SIZE/2); mesh.rotation.y = Math.PI; }
+        if(side==='left')  { mesh.position.set(-ROOM_SIZE/2, height/2, 0); mesh.rotation.y = Math.PI/2; }
+        if(side==='right') { mesh.position.set(ROOM_SIZE/2, height/2, 0); mesh.rotation.y = -Math.PI/2; }
         room.add(mesh);
       });
-      room.position.x = i * (size + 5);
+      room.position.x = i * ROOM_STEP;
       scene.add(room);
     }
 
@@ -177,7 +180,7 @@
     enemyBullets.length = 0;
 
     // reset pozycji i HP
-    controls.getObject().position.set(i*25, 2, 0);
+    controls.getObject().position.set(i*ROOM_STEP, 2, 0);
     roomIndex = i;
     overlayRoom.textContent = i+1;
     HP = 10000; overlayHP.textContent = HP;
@@ -200,12 +203,12 @@
       enemy.add(head);
 
       // pozycja losowa
-      const px = i*25 + (Math.random()-0.5)*10;
-      const pz = (Math.random()-0.5)*10;
+      const px = i*ROOM_STEP + (Math.random()-0.5)*ROOM_SIZE*0.5;
+      const pz = (Math.random()-0.5)*ROOM_SIZE*0.5;
       enemy.position.set(px,0,pz);
 
-      // hp + kierunek
-      enemy.userData = { hp:5, dir: new THREE.Vector3() };
+      // hp + kierunek i timer zmiany kierunku
+      enemy.userData = { hp:5, dir:new THREE.Vector3(), step:0 };
 
       scene.add(enemy);
       enemies.push(enemy);
@@ -289,8 +292,18 @@
 
     // AI wrogów
     enemies.forEach(e=>{
-      e.userData.dir.set(Math.random()-0.5, 0, Math.random()-0.5).normalize();
-      e.position.addScaledVector(e.userData.dir, 0.02);
+      if(e.userData.step <= 0){
+        e.userData.dir.set(Math.random()-0.5, 0, Math.random()-0.5).normalize();
+        e.userData.step = 50 + Math.random()*150;
+      }
+      const next = e.position.clone().addScaledVector(e.userData.dir, 0.02);
+      const centerX = roomIndex * ROOM_STEP;
+      if(Math.abs(next.x - centerX) > ROOM_SIZE/2 || Math.abs(next.z) > ROOM_SIZE/2){
+        e.userData.step = 0;
+      } else {
+        e.position.copy(next);
+        e.userData.step--;
+      }
       if(Math.random()<0.01){
         const geo = new THREE.SphereGeometry(0.1,8,8);
         const mat = new THREE.MeshBasicMaterial({ color:0xff0000 });


### PR DESCRIPTION
## Summary
- introduce room geometry constants and use them throughout
- spawn player and enemies using new constants
- add change-direction timer so enemies wander around the room instead of jittering

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6880f78a445c8324aa725dadb7cbe527